### PR TITLE
Fixed a possible division by zero when a server has no swap

### DIFF
--- a/src/commands/serverstatus.py
+++ b/src/commands/serverstatus.py
@@ -55,7 +55,10 @@ class ServerstatusRMDCommand(RMDCommand):
         for memory in memories:
             used = int(json_report[memory]['used'])
             total = int(json_report[memory]['total'])
-            memory_usage = float(used) / total
+            if total == 0:
+                memory_usage = 0
+            else:
+                memory_usage = float(used) / total
             if memory_usage > 95:
                 memory_status |= ERROR_STATE[0]
                 memory_status &= ERROR_STATE[0]


### PR DESCRIPTION
RMD fails to respond with a "division by zero error" when it runs on a server that has no swap space installed (as the total swap is zero).